### PR TITLE
fix: Save into cache a copy of result payload instead of the object with your original reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-
+## 0.7.13
+* d9f7164 fix: Save into cache a copy of result payload instead of the object with your original reference
 ## 0.7.12
 * 2d03d9f Merge branch 'master' of github.com:Codibre/remembered-redis
 * c9ab75f docs: updating readme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 * 2d03d9f Merge branch 'master' of github.com:Codibre/remembered-redis
 * c9ab75f docs: updating readme
 * 2853ab7 Merge pull request #3 from Codibre/fix/alternative-persistence-keys
-* ad1756e 0.7.11
+## 0.7.11
 * cb77922 fix: saving all keys during alternative persistence
-* 704355b 0.7.10
+## 0.7.10
 * 0330115 fix: ignoring too large keys for alternative persistence
 ## v0.7.9
 * 8aaa678 0.7.9

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-@remembered/redis - v0.7.12
+@remembered/redis - v0.7.13
 
-# @remembered/redis - v0.7.12
+# @remembered/redis - v0.7.13
 
 ## Table of contents
 

--- a/docs/classes/RememberedRedis.md
+++ b/docs/classes/RememberedRedis.md
@@ -1,4 +1,4 @@
-[@remembered/redis - v0.7.12](../README.md) / RememberedRedis
+[@remembered/redis - v0.7.13](../README.md) / RememberedRedis
 
 # Class: RememberedRedis
 

--- a/docs/interfaces/AlternativePersistence.md
+++ b/docs/interfaces/AlternativePersistence.md
@@ -1,4 +1,4 @@
-[@remembered/redis - v0.7.12](../README.md) / AlternativePersistence
+[@remembered/redis - v0.7.13](../README.md) / AlternativePersistence
 
 # Interface: AlternativePersistence
 

--- a/docs/interfaces/RememberedRedisConfig.md
+++ b/docs/interfaces/RememberedRedisConfig.md
@@ -1,4 +1,4 @@
-[@remembered/redis - v0.7.12](../README.md) / RememberedRedisConfig
+[@remembered/redis - v0.7.13](../README.md) / RememberedRedisConfig
 
 # Interface: RememberedRedisConfig
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remembered/redis",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@remembered/redis",
-      "version": "0.7.12",
+      "version": "0.7.13",
       "license": "MIT",
       "dependencies": {
         "clone": "^2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,10 @@
   "packages": {
     "": {
       "name": "@remembered/redis",
-      "version": "0.7.8",
+      "version": "0.7.12",
       "license": "MIT",
       "dependencies": {
+        "clone": "^2.1.2",
         "ioredis": "*",
         "multi-serializer": "*",
         "redis-semaphore": "*",
@@ -21,6 +22,7 @@
         "@semantic-release/git": "^10.0.0",
         "@semantic-release/npm": "^8.0.0",
         "@semantic-release/release-notes-generator": "^10.0.2",
+        "@types/clone": "^2.1.1",
         "@types/ioredis": "^4.27.4",
         "@types/jest": "^27.0.2",
         "@types/redis-mock": "^0.17.0",
@@ -1985,6 +1987,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/clone": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/clone/-/clone-2.1.1.tgz",
+      "integrity": "sha512-BZIU34bSYye0j/BFcPraiDZ5ka6MJADjcDVELGf7glr9K+iE8NYVjFslJFVWzskSxkLLyCrSPScE82/UUoBSvg==",
+      "dev": true
+    },
     "node_modules/@types/eslint": {
       "version": "7.2.8",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.8.tgz",
@@ -3240,6 +3248,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cluster-key-slot": {
@@ -15478,6 +15494,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/clone": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/clone/-/clone-2.1.1.tgz",
+      "integrity": "sha512-BZIU34bSYye0j/BFcPraiDZ5ka6MJADjcDVELGf7glr9K+iE8NYVjFslJFVWzskSxkLLyCrSPScE82/UUoBSvg==",
+      "dev": true
+    },
     "@types/eslint": {
       "version": "7.2.8",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.8.tgz",
@@ -16491,6 +16513,11 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
+    },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "cluster-key-slot": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@semantic-release/git": "^10.0.0",
     "@semantic-release/npm": "^8.0.0",
     "@semantic-release/release-notes-generator": "^10.0.2",
+    "@types/clone": "^2.1.1",
     "@types/ioredis": "^4.27.4",
     "@types/jest": "^27.0.2",
     "@types/redis-mock": "^0.17.0",
@@ -101,6 +102,7 @@
     "uuid": "^8.3.2"
   },
   "dependencies": {
+    "clone": "^2.1.2",
     "ioredis": "*",
     "multi-serializer": "*",
     "redis-semaphore": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@remembered/redis",
   "description": "A simple semaphore/cache lib using redis, extended from remembered package",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "author": {
     "name": "Thiago O Santos <tos.oliveira@gmail.com>"
   },


### PR DESCRIPTION
The **MaxSaveDelay** config brings to us considerable advantages, like a better use of S3 storage with files containing more search results being saved and fewer calls to S3. However, in the **MaxSaveDelay** space of time, the result object could be modified and a wrong object is saved into the cache, so in order to avoid this situation, my PR aims to save a copy (deep clone) of the cached result instead of your original reference.