### PR TITLE
feat: adding maxResultsPerSave

### DIFF
--- a/src/remembered-redis-config.ts
+++ b/src/remembered-redis-config.ts
@@ -19,6 +19,7 @@ export interface AlternativePersistence {
 	get(key: string): Promise<Buffer | string | undefined>;
 
 	maxSavingDelay?: number;
+	maxResultsPerSave?: number;
 }
 
 export interface RememberedRedisConfig extends RememberedConfig {


### PR DESCRIPTION
maxResultsPerSave allows alternativePersistances implementations to sign how many items must be included in each saved data. This is useful when you have a high requested service, you want to group many results in one data to minimize roundtrips, but you can't risk having too many, making the saving timeout not so trustful