### PR TITLE
Run and cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -879,6 +879,15 @@
         }
       }
     },
+    "@jest/expect-utils": {
+      "version": "29.3.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.3.1.tgz",
+      "integrity": "sha512-wlrznINZI5sMjwvUoLVk617ll/UYfGIZNxmbU+Pa7wmkL4vYzhV9R2pwVqUh4NWWuLQWkI8+8mOkxs//prKQ3g==",
+      "dev": true,
+      "requires": {
+        "jest-get-type": "^29.2.0"
+      }
+    },
     "@jest/fake-timers": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.5.1.tgz",
@@ -1167,6 +1176,15 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "@jest/schemas": {
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.0.0.tgz",
+      "integrity": "sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==",
+      "dev": true,
+      "requires": {
+        "@sinclair/typebox": "^0.24.1"
       }
     },
     "@jest/source-map": {
@@ -1591,6 +1609,12 @@
       "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
       "dev": true
     },
+    "@sinclair/typebox": {
+      "version": "0.24.51",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
+      "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==",
+      "dev": true
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -1739,13 +1763,149 @@
       }
     },
     "@types/jest": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.2.tgz",
-      "integrity": "sha512-4dRxkS/AFX0c5XW6IPMNOydLn2tEhNhJV7DnYK+0bjoJZ+QTmfucBlihX7aoEsh/ocYtkLC73UbnBXBXIxsULA==",
+      "version": "29.2.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.2.3.tgz",
+      "integrity": "sha512-6XwoEbmatfyoCjWRX7z0fKMmgYKe9+/HrviJ5k0X/tjJWHGAezZOfYaxqQKuzG/TvQyr+ktjm4jgbk0s4/oF2w==",
       "dev": true,
       "requires": {
-        "jest-diff": "^27.0.0",
-        "pretty-format": "^27.0.0"
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "29.3.1",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.3.1.tgz",
+          "integrity": "sha512-d0S0jmmTpjnhCmNpApgX3jrUZgZ22ivKJRvL2lli5hpCRoNnp1f85r2/wpKfXuYu8E7Jjh1hGfhPyup1NM5AmA==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "^29.0.0",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^17.0.8",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "17.0.14",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.14.tgz",
+          "integrity": "sha512-9Pj7abXoW1RSTcZaL2Hk6G2XyLMlp5ECdVC/Zf2p/KBjC3srijLGgRAXOBjtFrJoIrvxdTKyKDA14bEcbxBaWw==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "expect": {
+          "version": "29.3.1",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-29.3.1.tgz",
+          "integrity": "sha512-gGb1yTgU30Q0O/tQq+z30KBWv24ApkMgFUpvKBkyLUBL68Wv8dHdJxTBZFl/iT8K/bqDHvUYRH6IIN3rToopPA==",
+          "dev": true,
+          "requires": {
+            "@jest/expect-utils": "^29.3.1",
+            "jest-get-type": "^29.2.0",
+            "jest-matcher-utils": "^29.3.1",
+            "jest-message-util": "^29.3.1",
+            "jest-util": "^29.3.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+          "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-matcher-utils": {
+          "version": "29.3.1",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.3.1.tgz",
+          "integrity": "sha512-fkRMZUAScup3txIKfMe3AIZZmPEjWEdsPJFK3AIy5qRohWqQFg1qrmKfYXR9qEkNc7OdAu2N4KPHibEmy4HPeQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "jest-diff": "^29.3.1",
+            "jest-get-type": "^29.2.0",
+            "pretty-format": "^29.3.1"
+          }
+        },
+        "jest-message-util": {
+          "version": "29.3.1",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.3.1.tgz",
+          "integrity": "sha512-lMJTbgNcDm5z+6KDxWtqOFWlGQxD6XaYwBqHR8kmpkP+WWWG90I35kdtQHY67Ay5CSuydkTBbJG+tH9JShFCyA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.12.13",
+            "@jest/types": "^29.3.1",
+            "@types/stack-utils": "^2.0.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.9",
+            "micromatch": "^4.0.4",
+            "pretty-format": "^29.3.1",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.3"
+          }
+        },
+        "jest-util": {
+          "version": "29.3.1",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.3.1.tgz",
+          "integrity": "sha512-7YOVZaiX7RJLv76ZfHt4nbNEzzTRiMW/IiOG7ZOKmTXmoGBxUDefgMAxQubu6WPVqP5zSzAdZG0FfLcC7HOIFQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^29.3.1",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.9",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@types/json-schema": {
@@ -2675,9 +2835,9 @@
       "dev": true
     },
     "diff-sequences": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
-      "integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==",
+      "version": "29.3.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.3.1.tgz",
+      "integrity": "sha512-hlM3QR272NXCi4pq+N4Kok4kOp6EsgOM3ZSpJI7Da3UAs+Ttsi8MRmB6trM/lhyzUxGfOgnpkHtgqm5Q/CTcfQ==",
       "dev": true
     },
     "dir-glob": {
@@ -4326,15 +4486,15 @@
       }
     },
     "jest-diff": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.2.0.tgz",
-      "integrity": "sha512-QSO9WC6btFYWtRJ3Hac0sRrkspf7B01mGrrQEiCW6TobtViJ9RWL0EmOs/WnBsZDsI/Y2IoSHZA2x6offu0sYw==",
+      "version": "29.3.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.3.1.tgz",
+      "integrity": "sha512-vU8vyiO7568tmin2lA3r2DP8oRvzhvRcD4DjpXc6uGveQodyk7CKLhQlCSiwgx3g0pFaE88/KLZ0yaTWMc4Uiw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^27.0.6",
-        "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.2.0"
+        "diff-sequences": "^29.3.1",
+        "jest-get-type": "^29.2.0",
+        "pretty-format": "^29.3.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4717,9 +4877,9 @@
       }
     },
     "jest-get-type": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.6.tgz",
-      "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==",
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.2.0.tgz",
+      "integrity": "sha512-uXNJlg8hKFEnDgFsrCjznB+sTxdkuqiCL6zMgA75qEbAJjJYTs9XPrvDctrEig2GDow22T/LvHgO57iJhXB/UA==",
       "dev": true
     },
     "jest-haste-map": {
@@ -6784,21 +6944,26 @@
       }
     },
     "pretty-format": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.2.0.tgz",
-      "integrity": "sha512-KyJdmgBkMscLqo8A7K77omgLx5PWPiXJswtTtFV7XgVZv2+qPk6UivpXXO+5k6ZEbWIbLoKdx1pZ6ldINzbwTA==",
+      "version": "29.3.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.3.1.tgz",
+      "integrity": "sha512-FyLnmb1cYJV8biEIiRyzRFvs2lry7PPIvOqKVe1GCUEYg4YGmlx1qG9EJNMxArYm7piII4qb8UV1Pncq5dxmcg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.1",
-        "ansi-regex": "^5.0.0",
+        "@jest/schemas": "^29.0.0",
         "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
+        "react-is": "^18.0.0"
       },
       "dependencies": {
         "ansi-styles": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
           "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        },
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@codibre/confs": "1.1.0",
     "@types/clone": "^2.1.1",
     "@types/ioredis": "^4.27.4",
-    "@types/jest": "^27.0.2",
+    "@types/jest": "^29.2.3",
     "@types/node": "^17.0.30",
     "@types/opossum": "^6.2.0",
     "@types/redis-mock": "^0.17.0",

--- a/src/remembered-redis.ts
+++ b/src/remembered-redis.ts
@@ -119,7 +119,9 @@ export class RememberedRedis extends Remembered {
 		await this.tryTo(semaphore.acquire.bind(semaphore));
 		try {
 			const result = await callback();
-			if (result !== undefined && !noCacheIf?.(result)) this.updateCache(key, result, ttl);
+			if (result !== undefined && !noCacheIf?.(result)) {
+				await this.updateCache(key, result, ttl);
+			}
 			return result;
 		} finally {
 			this.tryTo(semaphore.release.bind(semaphore));


### PR DESCRIPTION
This method allows you always to obtain a real result, saving it into cache and taking advantage of the semaphore that remembered  redis uses.
This is useful when you get into a situation where you need a real result to be returned on a specific call, but other calls, you need it to always be from cache. This way, the real call can make the getFromCache call wait it to be concluded 