### PR TITLE
feat: using RedlockSemaphore from redis-semaphore

### DIFF
--- a/src/remembered-redis.ts
+++ b/src/remembered-redis.ts
@@ -1,7 +1,7 @@
 import { v4 } from 'uuid';
 import { Remembered } from 'remembered';
 import { Redis } from 'ioredis';
-import { LockOptions, Semaphore } from 'redis-semaphore';
+import { LockOptions, RedlockSemaphore } from 'redis-semaphore';
 import {
 	RememberedRedisConfig,
 	TryTo,
@@ -206,8 +206,8 @@ export class RememberedRedis extends Remembered {
 				},
 			};
 		}
-		return new Semaphore(
-			redis,
+		return new RedlockSemaphore(
+			[redis],
 			`${this.redisPrefix}REMEMBERED-SEMAPHORE:${key}`,
 			1,
 			{


### PR DESCRIPTION
redlock showed to be worse than Redislock in the matter of the volume of fails caused, so, we're testing now redis-semaphore redlock implementation
![image](https://github.com/codibre/remembered-redis/assets/5713887/cd2a514b-6cdf-4e82-9fa7-ec5515ccbca9)
