### PR TITLE
feat: using Mutex from redis-semaphore

### DIFF
--- a/src/remembered-redis.ts
+++ b/src/remembered-redis.ts
@@ -1,7 +1,7 @@
 import { v4 } from 'uuid';
 import { Remembered } from 'remembered';
 import { Redis } from 'ioredis';
-import { LockOptions, RedlockSemaphore } from 'redis-semaphore';
+import { LockOptions, Mutex } from 'redis-semaphore';
 import {
 	RememberedRedisConfig,
 	TryTo,
@@ -206,10 +206,9 @@ export class RememberedRedis extends Remembered {
 				},
 			};
 		}
-		return new RedlockSemaphore(
+		return new Mutex(
 			[redis],
 			`${this.redisPrefix}REMEMBERED-SEMAPHORE:${key}`,
-			1,
 			{
 				...this.semaphoreConfig,
 				onLockLost: (err) => this.settings.onLockLost?.(key, err),


### PR DESCRIPTION
There was no difference between RedlockSemaphore from Redis semaphore and The normal semaphore itself

![image](https://github.com/codibre/remembered-redis/assets/5713887/b7856ce5-8469-4417-8ead-ef3eb30c5892)


This shows that this implementation is only worth when we have multiple redis instances. In this PR, will now test Mutex from redis-semaphore to see if we can get any better