### PR TITLE
fix: indicating to alternative persistence whether it is trying to get before first semaphore

### DIFF
--- a/src/remembered-redis-config.ts
+++ b/src/remembered-redis-config.ts
@@ -16,7 +16,7 @@ export interface AlternativePersistence {
 	 * Get the content for the informed key
 	 * @param key the key for the content
 	 */
-	get(key: string): Promise<Buffer | string | undefined>;
+	get(key: string, firstCheck: boolean): Promise<Buffer | string | undefined>;
 
 	maxSavingDelay?: number;
 	maxResultsPerSave?: number;

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -308,7 +308,7 @@ describe('index.ts', () => {
 
 			expect(target['getSemaphore']).toHaveCallsLike(['my key']);
 			expect(acquire).toHaveCallsLike([semaphore]);
-			expect(target['getFromCacheInternal']).toHaveCallsLike(['my key']);
+			expect(target['getFromCacheInternal']).toHaveCallsLike(['my key', false]);
 			expect(release).toHaveCallsLike([semaphore]);
 			expect(target['tryTo']).toHaveCallsLike(
 				['acquire result'],
@@ -322,7 +322,7 @@ describe('index.ts', () => {
 
 			expect(target['getSemaphore']).toHaveCallsLike(['my key']);
 			expect(acquire).toHaveCallsLike([semaphore]);
-			expect(target['getFromCacheInternal']).toHaveCallsLike(['my key']);
+			expect(target['getFromCacheInternal']).toHaveCallsLike(['my key', false]);
 			expect(release).toHaveCallsLike([semaphore]);
 			expect(target['tryTo']).toHaveCallsLike(
 				['acquire result'],
@@ -336,7 +336,7 @@ describe('index.ts', () => {
 
 			expect(target['getSemaphore']).toHaveCallsLike(['my key']);
 			expect(acquire).toHaveCallsLike();
-			expect(target['getFromCacheInternal']).toHaveCallsLike(['my key']);
+			expect(target['getFromCacheInternal']).toHaveCallsLike(['my key', false]);
 			expect(release).toHaveCallsLike();
 			expect(target['tryTo']).toHaveCallsLike();
 			expect(result).toBe('expected result');


### PR DESCRIPTION
It'll allow to avoid creating unnecessary logs