### PR TITLE
fix: bettering lint and avoiding floating promises

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,9 @@ module.exports = {
     '@typescript-eslint/no-unnecessary-type-assertion': 'error',
     '@typescript-eslint/no-unused-expressions': 'warn',
     '@typescript-eslint/no-use-before-define': 'error',
+		'no-return-await': 'off',
+		'@typescript-eslint/return-await': 'error',
+		'@typescript-eslint/no-floating-promises': 'error',
     '@typescript-eslint/quotes': [
       'error',
       'single',

--- a/src/dont-wait.ts
+++ b/src/dont-wait.ts
@@ -1,0 +1,5 @@
+import { LogError, TryTo } from './remembered-redis-config';
+
+export function dontWaitFactory(logError: LogError | undefined, tryTo: TryTo) {
+	return (cb: () => Promise<unknown>) => setImmediate(() => tryTo(cb));
+}

--- a/src/get-semaphore-config.ts
+++ b/src/get-semaphore-config.ts
@@ -18,5 +18,5 @@ export function getSemaphoreConfig(config: RememberedRedisConfig): LockOptions {
 
 export interface RememberedSemaphore {
 	acquire(): Promise<void>;
-	release(): Promise<void>;
+	release(): void;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
+export * from './dont-wait';
 export * from './remembered-redis';
 export * from './remembered-redis-config';

--- a/src/remembered-redis-config.ts
+++ b/src/remembered-redis-config.ts
@@ -1,8 +1,8 @@
 import { RememberedConfig, Ttl } from 'remembered';
 
 export type LogError = (message: string) => any;
-export type Action = () => PromiseLike<void>;
-export type TryTo = (action: Action) => PromiseLike<void>;
+export type Action<T> = () => PromiseLike<T>;
+export type TryTo = <T>(action: Action<T>) => Promise<T | undefined>;
 export interface AlternativePersistence {
 	/**
 	 * Saves the informed content

--- a/src/try-to-factory.ts
+++ b/src/try-to-factory.ts
@@ -1,9 +1,9 @@
 import { Action, LogError, TryTo } from './remembered-redis-config';
 
 export function tryToFactory(logError: LogError | undefined): TryTo {
-	return async function (action: Action) {
+	return async function <T>(action: Action<T>) {
 		try {
-			await action();
+			return await action();
 		} catch (err: any) {
 			logError?.(err.message);
 		}

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -206,9 +206,10 @@ describe('index.ts', () => {
 			acquire = jest.fn().mockReturnValue('acquire result');
 			release = jest.fn().mockReturnValue('release result');
 			jest.spyOn(target, 'updateCache').mockResolvedValue(undefined);
-			semaphore = { acquire: { bind: acquire }, release: { bind: release } };
+			semaphore = { acquire, release };
 			jest.spyOn(target, 'getSemaphore' as any).mockReturnValue(semaphore);
 			jest.spyOn(target, 'tryTo' as any).mockResolvedValue(undefined);
+			jest.spyOn(target, 'dontWait' as any).mockReturnValue(undefined);
 		});
 
 		it('should run the specified command and save it into cache, when result is defined and noCacheIf is not informed', async () => {
@@ -221,18 +222,14 @@ describe('index.ts', () => {
 
 			expect(result).toBe('expected value');
 			expect(target['getSemaphore']).toHaveCallsLike(['my-key']);
-			expect(acquire).toHaveCallsLike([semaphore]);
+			expect(acquire).toHaveCallsLike([]);
 			expect(callback).toHaveCallsLike([]);
 			expect(target.updateCache).toHaveCallsLike([
 				'my-key',
 				'expected value',
 				'my ttl',
 			]);
-			expect(release).toHaveCallsLike([semaphore]);
-			expect(target['tryTo']).toHaveCallsLike(
-				['acquire result'],
-				['release result'],
-			);
+			expect(release).toHaveCallsLike([]);
 		});
 
 		it('should run the specified command and save it into cache, when result is defined and noCacheIf returns false', async () => {
@@ -247,7 +244,7 @@ describe('index.ts', () => {
 
 			expect(result).toBe('expected value');
 			expect(target['getSemaphore']).toHaveCallsLike(['my-key']);
-			expect(acquire).toHaveCallsLike([semaphore]);
+			expect(acquire).toHaveCallsLike([]);
 			expect(callback).toHaveCallsLike([]);
 			expect(noCacheIf).toHaveCallsLike(['expected value']);
 			expect(target.updateCache).toHaveCallsLike([
@@ -255,11 +252,7 @@ describe('index.ts', () => {
 				'expected value',
 				'my ttl',
 			]);
-			expect(release).toHaveCallsLike([semaphore]);
-			expect(target['tryTo']).toHaveCallsLike(
-				['acquire result'],
-				['release result'],
-			);
+			expect(release).toHaveCallsLike([]);
 		});
 
 		it('should run the specified command and not save it into cache, when result is defined and noCacheIf returns true', async () => {
@@ -274,15 +267,11 @@ describe('index.ts', () => {
 
 			expect(result).toBe('expected value');
 			expect(target['getSemaphore']).toHaveCallsLike(['my-key']);
-			expect(acquire).toHaveCallsLike([semaphore]);
+			expect(acquire).toHaveCallsLike([]);
 			expect(callback).toHaveCallsLike([]);
 			expect(noCacheIf).toHaveCallsLike(['expected value']);
 			expect(target.updateCache).toHaveCallsLike();
-			expect(release).toHaveCallsLike([semaphore]);
-			expect(target['tryTo']).toHaveCallsLike(
-				['acquire result'],
-				['release result'],
-			);
+			expect(release).toHaveCallsLike([]);
 		});
 	});
 
@@ -294,25 +283,20 @@ describe('index.ts', () => {
 		beforeEach(() => {
 			acquire = jest.fn().mockReturnValue('acquire result');
 			release = jest.fn().mockReturnValue('release result');
-			semaphore = { acquire: { bind: acquire }, release: { bind: release } };
+			semaphore = { acquire, release };
 			jest.spyOn(target, 'getSemaphore' as any).mockReturnValue(semaphore);
 			jest
 				.spyOn(target, 'getFromCacheInternal' as any)
 				.mockResolvedValue('expected result');
-			jest.spyOn(target, 'tryTo' as any).mockResolvedValue(undefined);
 		});
 
 		it('should acquire semaphore when noSemaphore is not informed', async () => {
 			const result = await target.getFromCache('my key');
 
 			expect(target['getSemaphore']).toHaveCallsLike(['my key']);
-			expect(acquire).toHaveCallsLike([semaphore]);
+			expect(acquire).toHaveCallsLike([]);
 			expect(target['getFromCacheInternal']).toHaveCallsLike(['my key', false]);
-			expect(release).toHaveCallsLike([semaphore]);
-			expect(target['tryTo']).toHaveCallsLike(
-				['acquire result'],
-				['release result'],
-			);
+			expect(release).toHaveCallsLike([]);
 			expect(result).toBe('expected result');
 		});
 
@@ -320,13 +304,9 @@ describe('index.ts', () => {
 			const result = await target.getFromCache('my key', false);
 
 			expect(target['getSemaphore']).toHaveCallsLike(['my key']);
-			expect(acquire).toHaveCallsLike([semaphore]);
+			expect(acquire).toHaveCallsLike([]);
 			expect(target['getFromCacheInternal']).toHaveCallsLike(['my key', false]);
-			expect(release).toHaveCallsLike([semaphore]);
-			expect(target['tryTo']).toHaveCallsLike(
-				['acquire result'],
-				['release result'],
-			);
+			expect(release).toHaveCallsLike([]);
 			expect(result).toBe('expected result');
 		});
 
@@ -337,7 +317,6 @@ describe('index.ts', () => {
 			expect(acquire).toHaveCallsLike();
 			expect(target['getFromCacheInternal']).toHaveCallsLike(['my key', false]);
 			expect(release).toHaveCallsLike();
-			expect(target['tryTo']).toHaveCallsLike();
 			expect(result).toBe('expected result');
 		});
 	});

--- a/test/unit/try-to-factory.spec.ts
+++ b/test/unit/try-to-factory.spec.ts
@@ -16,7 +16,7 @@ describe(tryToFactory.name, () => {
 
 		expect(action).toHaveCallsLike([]);
 		expect(logError).toHaveCallsLike();
-		expect(result).toBeUndefined();
+		expect(result).toBe('test');
 	});
 
 	it('should return a function that runs the action and log an error, if the action throws one', async () => {


### PR DESCRIPTION
Some floating promises could make semaphores to be released before the work as done. We bettered lint and fixed the weak spots to prevent it from happening