### PR TITLE
feat: implementing external semaphore support

### DIFF
--- a/src/remembered-redis-config.ts
+++ b/src/remembered-redis-config.ts
@@ -22,6 +22,10 @@ export interface AlternativePersistence {
 	maxResultsPerSave?: number;
 }
 
+export interface Semaphore {
+	acquire(key: string): Promise<() => Promise<void>>;
+}
+
 export interface RememberedRedisConfig extends RememberedConfig {
 	redisTtl?: Ttl;
 	redisPrefix?: string;
@@ -39,4 +43,5 @@ export interface RememberedRedisConfig extends RememberedConfig {
 	 * When informed, redis is used only for ttl control, but the real data is persisted using these methods
 	 */
 	alternativePersistence?: AlternativePersistence;
+	semaphore?: Semaphore;
 }

--- a/src/remembered-redis-config.ts
+++ b/src/remembered-redis-config.ts
@@ -23,7 +23,7 @@ export interface AlternativePersistence {
 }
 
 export interface Semaphore {
-	acquire(key: string): Promise<() => Promise<void>>;
+	acquire(key: string): Promise<() => Promise<unknown>>;
 }
 
 export interface RememberedRedisConfig extends RememberedConfig {

--- a/src/remembered-redis.ts
+++ b/src/remembered-redis.ts
@@ -148,7 +148,9 @@ export class RememberedRedis extends Remembered {
 			}
 			return result;
 		} finally {
-			this.dontWait(() => saveCache.then(release));
+			if (release) {
+				this.dontWait(() => saveCache.then(() => release()));
+			}
 		}
 	}
 

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -310,13 +310,15 @@ describe('index.ts', () => {
 		});
 
 		it('should use custom semaphore when it set', async () => {
+      jest.spyOn(target, 'dontWait' as any).mockReturnValue('wrapped release');
 			target['settings'].semaphore = {
 				acquire: jest.fn().mockReturnValue('my release function'),
 			};
 
 			const result = await target['acquire'](key);
 
-			expect(result).toEqual('my release function');
+			expect(result()).toEqual('wrapped release');
+      expect(target['dontWait']).toHaveCallsLike(['my release function']);
 		});
 	});
 });


### PR DESCRIPTION
With this new option, you can inform a custom semaphore control to be used with remembered redis