### PR TITLE
(AlternativePersistence) add shouldUseAlternativePersistence function

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ export class RedisCache implements AlternativePersistence {
 
 This may not seem reasonable, but, as you join many results into one can when maxSavingDelay > 0, you can favor the compression with this, and save a lot of memory in your instance.
 
+There is also the option to dynamically decide whether to use alternative persistence or Redis as the storage. Simply define the **shouldUseAlternativePersistence** function, and whenever it returns false, the alternative persistence is ignored. A common use case is when your application manages data with different lifetime: Redis can handle data with short expiration times, while the alternative persistence stores longer-lived data, optimizing storage costs.
+
 ## License
 
 Licensed under [MIT](https://en.wikipedia.org/wiki/MIT_License).

--- a/src/remembered-redis-config.ts
+++ b/src/remembered-redis-config.ts
@@ -8,7 +8,7 @@ export interface AlternativePersistence {
 	 * Saves the informed content
 	 * @param key the key for the content
 	 * @param content the content to be saved
-	 * @param ttl the ttl redis will maintain the reference for this key, in seconds
+	 * @param ttl the expiration time, in seconds, that Redis will use to maintain the reference for this key
 	 */
 	save(key: string, content: string | Buffer, ttl: number): Promise<void>;
 
@@ -17,6 +17,16 @@ export interface AlternativePersistence {
 	 * @param key the key for the content
 	 */
 	get(key: string, firstCheck: boolean): Promise<Buffer | string | undefined>;
+
+	/**
+	 * If defined and returns true, the alternative persistence is applied; otherwise it is not.
+	 * @param content the content to be saved
+	 * @param ttl the expiration time, in seconds, that Redis will use to maintain the reference for this key
+	 */
+	shouldUseAlternativePersistence?: (
+		content: unknown,
+		ttl: number,
+	) => boolean;
 
 	maxSavingDelay?: number;
 	maxResultsPerSave?: number;

--- a/src/remembered-redis-config.ts
+++ b/src/remembered-redis-config.ts
@@ -23,10 +23,7 @@ export interface AlternativePersistence {
 	 * @param content the content to be saved
 	 * @param ttl the expiration time, in seconds, that Redis will use to maintain the reference for this key
 	 */
-	shouldUseAlternativePersistence?: (
-		content: unknown,
-		ttl: number,
-	) => boolean;
+	shouldUseAlternativePersistence?: (content: unknown, ttl: number) => boolean;
 
 	maxSavingDelay?: number;
 	maxResultsPerSave?: number;

--- a/src/remembered-redis.ts
+++ b/src/remembered-redis.ts
@@ -205,7 +205,15 @@ export class RememberedRedis extends Remembered {
 			const redisKey = this.getRedisKey(cacheKey);
 			const realTtl = ttl || 1;
 			const resultCopy: T = clone(result);
-			if (this.alternativePersistence) {
+			if (
+				this.alternativePersistence &&
+				(this.alternativePersistence.shouldUseAlternativePersistence
+					? this.alternativePersistence.shouldUseAlternativePersistence(
+							resultCopy,
+							realTtl,
+					  )
+					: true)
+			) {
 				if (!this.alternativePersistence.maxSavingDelay) {
 					await this.persistKeys(
 						{

--- a/src/remembered-redis.ts
+++ b/src/remembered-redis.ts
@@ -64,14 +64,14 @@ const MAX_ALTERNATIVE_KEY_SIZE = 50;
 const TTL_MAP_POS = 2;
 
 export class RememberedRedis extends Remembered {
-	private semaphoreConfig: LockOptions;
-	private redisPrefix: string;
-	private redisTtl?: <T>(r: T) => number;
-	private tryTo: TryTo;
-	private dontWait: ReturnType<typeof dontWaitFactory>;
-	private onCache?: (key: string) => void;
-	private onError?: (key: string, err: Error) => any;
-	private alternativePersistence?: AlternativePersistence;
+	private readonly semaphoreConfig: LockOptions;
+	private readonly redisPrefix: string;
+	private readonly redisTtl?: <T>(r: T) => number;
+	private readonly tryTo: TryTo;
+	private readonly dontWait: ReturnType<typeof dontWaitFactory>;
+	private readonly onCache?: (key: string) => void;
+	private readonly onError?: (key: string, err: Error) => any;
+	private readonly alternativePersistence?: AlternativePersistence;
 	private savingObjects?: SavingObjects;
 	private waitSaving = false;
 	private savingPromise?: Promise<unknown>;

--- a/src/remembered-redis.ts
+++ b/src/remembered-redis.ts
@@ -207,12 +207,11 @@ export class RememberedRedis extends Remembered {
 			const resultCopy: T = clone(result);
 			if (
 				this.alternativePersistence &&
-				(this.alternativePersistence.shouldUseAlternativePersistence
-					? this.alternativePersistence.shouldUseAlternativePersistence(
-							resultCopy,
-							realTtl,
-					  )
-					: true)
+				(!this.alternativePersistence.shouldUseAlternativePersistence ||
+					this.alternativePersistence.shouldUseAlternativePersistence(
+						resultCopy,
+						realTtl,
+					))
 			) {
 				if (!this.alternativePersistence.maxSavingDelay) {
 					await this.persistKeys(


### PR DESCRIPTION
Using S3 as an alternative persistence can become costly when AWS experiences a high volume of PUT operations. The library provides the **maxSavingDelay** configuration to help mitigate this, but storing large payloads in memory can introduce additional challenges.

This PR introduces another option to better balance storage costs: the addition of the **shouldUseAlternativePersistence** function to the **AlternativePersistence** interface. When this function is defined, it allows you to dynamically control whether alternative persistence is used. If the function returns false, alternative persistence is bypassed. A common use case is when your application manages data with different lifetime: Redis can handle data with short expiration times, while the alternative persistence stores longer-lived data, optimizing storage costs."